### PR TITLE
Fix: Skip action correctly on non-PR events to prevent ci errors

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,14 +29,16 @@ runs:
     id: check_event
     shell: bash
     run: |
-      if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+      if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+        echo "is_pr=true" >> $GITHUB_OUTPUT
+      else
+        echo "is_pr=false" >> $GITHUB_OUTPUT
         echo "Not a pull request event. Skipping action."
-        exit 0
       fi
-      echo "This is a pull request event."
 
   - name: Check if PR head branch matches allowed patterns
     id: check_branch
+    if: steps.check_event.outputs.is_pr == 'true'
     shell: bash
     run: |
       HEAD_BRANCH="${{ github.event.pull_request.head.ref }}"
@@ -67,6 +69,7 @@ runs:
 
   - name: Generate comment message
     id: generate_comment
+    if: steps.check_event.outputs.is_pr == 'true' && (steps.check_branch.outputs.branch_allowed == 'true' || steps.check_branch.outputs.branch_allowed == '')
     shell: bash
     run: |
       {
@@ -82,6 +85,7 @@ runs:
       } >> "$GITHUB_OUTPUT"
 
   - name: Comment on PR
+    if: steps.check_event.outputs.is_pr == 'true' && (steps.check_branch.outputs.branch_allowed == 'true' || steps.check_branch.outputs.branch_allowed == '')
     uses: thollander/actions-comment-pull-request@v2
     with:
       message: ${{ steps.generate_comment.outputs.comment }}


### PR DESCRIPTION
First, I want to say that I've been using this action in my projects and it's incredibly useful! Thank you for creating such a convenient tool for Cloudflare Pages deployments - it has significantly improved our workflow.

## Problem
Currently, when this action runs on non-PR events (like push events), it attempts to skip execution by using exit 0 in the first step. However, in Composite Actions, this doesn't prevent subsequent steps from running. As a result, when the PR comment step runs on a non-PR event, it fails with the error `Error: No issue/pull request in input neither in current context.`

You can see the error in the screenshot below:
![CleanShot 2025-03-23 at 22 25 31@2x](https://github.com/user-attachments/assets/61344662-533e-4f60-94ef-8019a1aa8d37)

For further reference, you can see the full workflow run at this URL:
https://github.com/okm321/okmkm-blog/actions/runs/14019088314/job/39248580191

## Solution
This PR fixes the issue by:
- Adding an is_pr output variable to the event check step
- Using conditional execution (if: statements) on subsequent steps
- Only running the PR comment steps when the event is a pull request and the branch matches allowed patterns

## Changes
- Refactored the flow to use GitHub Actions' step outputs for conditional execution
- Improved error handling to gracefully skip action on non-PR events
- Maintained all existing functionality for PR events

## Testing
I've tested this fix by implementing the modified Composite Action in my own repository. I verified that:
- On push events: the action now gracefully skips without throwing errors
- On PR events: comments are still correctly posted with deployment information

This confirms that the fix works as expected in real-world usage scenarios while maintaining all existing functionality.

You can see the working examples here:

PR event: https://github.com/okm321/okmkm-blog/actions/runs/14019349029/job/39249162308?pr=3
Push event: https://github.com/okm321/okmkm-blog/actions/runs/14019368610/job/39249208970

![CleanShot 2025-03-23 at 22 31 02@2x](https://github.com/user-attachments/assets/8c869890-cc4e-4c0b-b771-8c05013ea9e7)
